### PR TITLE
hardware acceleration for camera2 api fix

### DIFF
--- a/Samples/Android/MainActivity.cs
+++ b/Samples/Android/MainActivity.cs
@@ -14,7 +14,7 @@ using Java.Lang;
 
 namespace Android
 {
-	[Activity (Label = "BlinkID Xamarin", MainLauncher = true, Icon = "@mipmap/icon")]
+	[Activity (Label = "BlinkID Xamarin", MainLauncher = true, Icon = "@mipmap/icon", HardwareAccelerated = true)]
 	public class MainActivity : Activity
 	{
 		public const string LICENSE_KEY = "YXYKNFI6-IL7BPDQO-LWJTJLN4-ZV7RAXUH-F7QX4XUH-F7QX4XUH-F7QX57QA-DY33G5LK";

--- a/Samples/Android/Properties/AndroidManifest.xml
+++ b/Samples/Android/Properties/AndroidManifest.xml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.microblink.blinkid.xamarin.android.sample">
-	<uses-sdk android:minSdkVersion="11" android:targetSdkVersion="23" />
+	<uses-sdk />
 	<uses-permission android:name="android.permission.CAMERA" />
 	<uses-feature android:name="android.hardware.camera" android:required="false" />
 	<uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 	<uses-feature android:glEsVersion="0x00020000" android:required="false" />
-	<application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name">
+	<application android:allowBackup="true" android:icon="@mipmap/icon" android:label="@string/app_name" android:hardwareAccelerated="true">
 		<activity android:name="com.microblink.wrapper.xamarin.ScanCardWrapper" android:screenOrientation="portrait" />
 	</application>
 </manifest>


### PR DESCRIPTION
App crashes on phones that use camera2 API because the surfaceTexture can't be created without hardware acceleration. Added hardware acceleration in both project manifest and activity attribute.