### PR TITLE
Added overlaySettings as a property so it doesn't get destroyed by gc

### DIFF
--- a/Binding/Forms/BlinkID.Forms/BlinkID.Forms.iOS/MicroblinkScannerImplementation.cs
+++ b/Binding/Forms/BlinkID.Forms/BlinkID.Forms.iOS/MicroblinkScannerImplementation.cs
@@ -12,11 +12,14 @@ namespace Microblink.Forms.iOS
     {
         // ensure RecognizerRunnerVC does not get GC-ed while it is required for ObjC code
         IMBRecognizerRunnerViewController recognizerRunnerViewController;
+        // ensure OverlaySettings don't get GC-ed while they are required for ObjC code
+        IOverlaySettings overlaySettings;
 
         public MicroblinkScannerImplementation(string licenseKey, string licensee, bool showTimeLimitedLicenseWarning)
         {
             MBMicroblinkSDK.SharedInstance.ShowLicenseKeyTimeLimitedWarning = showTimeLimitedLicenseWarning;
             if (licensee == null) 
+
             {
                 MBMicroblinkSDK.SharedInstance.SetLicenseKey(licenseKey);
             }
@@ -28,6 +31,7 @@ namespace Microblink.Forms.iOS
 
         public void Scan(IOverlaySettings overlaySettings)
         {
+            this.overlaySettings = overlaySettings;
             var window = UIApplication.SharedApplication.KeyWindow;
             var vc = window.RootViewController;
 


### PR DESCRIPTION
 * Added overlay settings to property, so it won't get deleted by GC.
 * Fixes issue on iOS where after accepting Allow Camera prompt there are no scanning callbacks because delegate gets destroyed.